### PR TITLE
Add embed switcher and countdown timers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,11 @@ defaults:
       yahNews: true
   -
     scope:
+      path: "assets"
+    values:
+      layout: "raw"
+  -
+    scope:
       path: "about"
     values:
       titlecat: "about"

--- a/_data/embed-switcher.yml
+++ b/_data/embed-switcher.yml
@@ -1,0 +1,50 @@
+#===========================================================
+#
+# Bronystate 3.0 - Embed Switcher
+# Shizuka Kamishima - 2015-11-23
+#
+#
+# #########################################################
+# !!! DO NOT UNDER ANY CIRCUMSTANCES COMMIT STREAM KEYS !!!
+# #########################################################
+#
+#
+# USAGE:
+# 'live' is the name of the embed currently live on site
+# 'embeds' is a list of embed srcs to put on page
+#   (add comments for detail)
+#
+# NEW STREAMS:
+# preferably create stream name as "BRST <name>" so it's
+#   easier for people to search (i.e. "BRST Amethyst")
+#   rather than the date naming method we used before
+#
+#===========================================================
+
+# Name of the embed to put on page - don't misspell it!
+# Ex. "diamond", "emerald", "ponies-in-boxes"
+live: "diamond"
+
+embeds:
+  # MAIN STREAMS
+  amethyst:   ""
+  beryl:      ""
+  cookie:     "http://www.ustream.tv/embed/16198304?html5ui=1" # BRST20131018
+  diamond:    "http://www.ustream.tv/embed/16227134?html5ui=1" # BRST20131023
+  emerald:    "http://www.ustream.tv/embed/16296194?html5ui=1" # BRST20131106
+  feldspar:   ""
+  garnet:     ""
+  hematite:   ""
+  iolite:     ""
+  jade:       ""
+  lapis:      ""
+  malachite:  ""
+  opal:       ""
+  pearl:      ""
+  quartz:     ""
+  ruby:       ""
+  sapphire:   ""
+  topaz:      ""
+  # YOUTUBE LOOPS
+  fireplace: "http://www.youtube.com/embed/e_BL5EKwSqE?&autoplay=1&rel=0&loop=1&showinfo=0&hd=1&autohide=1&playlist=e_BL5EKwSqE"
+  ponies-in-boxes: "http://www.youtube.com/embed/tJnWo5Jx7W8?&autoplay=1&rel=0&loop=1&showinfo=0&modestbranding=1&controls=0&hd=1&autohide=1&playlist=tJnWo5Jx7W8"

--- a/_data/embed-switcher.yml
+++ b/_data/embed-switcher.yml
@@ -31,5 +31,6 @@ embeds:
   sapphire:   ""
   topaz:      ""
   # YOUTUBE LOOPS
-  fireplace: "http://www.youtube.com/embed/e_BL5EKwSqE?&autoplay=1&rel=0&loop=1&showinfo=0&hd=1&autohide=1&playlist=e_BL5EKwSqE"
-  ponies-in-boxes: "http://www.youtube.com/embed/tJnWo5Jx7W8?&autoplay=1&rel=0&loop=1&showinfo=0&modestbranding=1&controls=0&hd=1&autohide=1&playlist=tJnWo5Jx7W8"
+  # /embed/VIDEO_ID?copyeverythingelse
+  fireplace: "http://www.youtube.com/embed/e_BL5EKwSqE?&autoplay=1&rel=0&loop=1&modestbranding=1&showinfo=0&iv_load_policy=3"
+  ponies-in-boxes: "http://www.youtube.com/embed/tJnWo5Jx7W8?&autoplay=1&rel=0&loop=1&modestbranding=1&showinfo=0&iv_load_policy=3"

--- a/_data/embed-switcher.yml
+++ b/_data/embed-switcher.yml
@@ -34,3 +34,7 @@ embeds:
   # /embed/VIDEO_ID?copyeverythingelse
   fireplace: "http://www.youtube.com/embed/e_BL5EKwSqE?&autoplay=1&rel=0&loop=1&modestbranding=1&showinfo=0&iv_load_policy=3"
   ponies-in-boxes: "http://www.youtube.com/embed/tJnWo5Jx7W8?&autoplay=1&rel=0&loop=1&modestbranding=1&showinfo=0&iv_load_policy=3"
+
+# If you flub the live name, or there's otherwise no url, load Technical Derpiculties instead
+# To force this to load, leave "live" blank
+failsafe: "http://www.youtube.com/embed/9YF4uMesUHw?&autoplay=1&rel=0&loop=1&modestbranding=1&showinfo=0&iv_load_policy=3"

--- a/_data/embed-switcher.yml
+++ b/_data/embed-switcher.yml
@@ -1,30 +1,15 @@
-#===========================================================
-#
 # Bronystate 3.0 - Embed Switcher
 # Shizuka Kamishima - 2015-11-23
-#
-#
-# #########################################################
-# !!! DO NOT UNDER ANY CIRCUMSTANCES COMMIT STREAM KEYS !!!
-# #########################################################
-#
-#
-# USAGE:
-# 'live' is the name of the embed currently live on site
-# 'embeds' is a list of embed srcs to put on page
-#   (add comments for detail)
-#
-# NEW STREAMS:
-# preferably create stream name as "BRST <name>" so it's
-#   easier for people to search (i.e. "BRST Amethyst")
-#   rather than the date naming method we used before
-#
-#===========================================================
+
+###########################################################
+#!!! DO NOT UNDER ANY CIRCUMSTANCES COMMIT STREAM KEYS !!!#
+###########################################################
 
 # Name of the embed to put on page - don't misspell it!
 # Ex. "diamond", "emerald", "ponies-in-boxes"
 live: "diamond"
 
+# List of embed src, what goes in the "" will go into iframe
 embeds:
   # MAIN STREAMS
   amethyst:   ""

--- a/_data/timers.yml
+++ b/_data/timers.yml
@@ -3,12 +3,12 @@
 # Shizuka Kamishima - 2015-11-23
 #
 # timers:
-#   - title: "Friday Movie Night"
-#     time: "2015-11-27 19:00 -0500"
+#   - title: Friday Movie Night
+#     time: 2015-11-27 19:00 -0500
 #     url: "/news/2015-11-20-lottery.html"
 #
-#   - title: 'Pony Episode'
-#     time: "2015-11-28 10:30 -0600"
+#   - title: Pony Episode
+#     time: 2015-11-28 10:30 -0600
 # 
 # Spaces matter! Line up the - and values, blank lines okay
 # "url" field is optional, "title" and "time" are not
@@ -47,8 +47,8 @@ show-in-sidebar: 3
 
 # List of timers
 timers:
-  - title: "Friday Movie Night"
+  - title: Friday Movie Night
     time: 2015-11-27 18:00 -0600
   
-  - title: "Season Finale"
+  - title: Season Finale
     time: 2015-11-28 08:00 -0800

--- a/_data/timers.yml
+++ b/_data/timers.yml
@@ -1,0 +1,54 @@
+#==========================================================
+# Bronystate 3.0 - Countdown Timers
+# Shizuka Kamishima - 2015-11-23
+#
+# timers:
+#   - title: "Friday Movie Night"
+#     time: "2015-11-27 19:00 -0500"
+#     url: "/news/2015-11-20-lottery.html"
+#
+#   - title: 'Pony Episode'
+#     time: "2015-11-28 10:30 -0600"
+# 
+# Spaces matter! Line up the - and values, blank lines okay
+# "url" field is optional, "title" and "time" are not
+# "title" will be lowercased when inserted into header bar
+# Remember most recent lottery appears below stream
+#
+# TIME FORMAT: YYYY-MM-DD HH:MM -TTTT (or +TTTT)
+#   YYYY: year
+#   MM: month
+#   DD: day
+#   HH: hour
+#   MM: minute
+#   TTTT: timezone offset from UTC
+#
+# Enter times in *your* timezone
+#   unless you know the time's EST/EDT time
+#   or +0000 for UTC
+# For Daylight Savings, input the time it *will* be
+# Safest to always specify timezone, will assume UTC without it
+#
+# NOTE: EXPIRED TIMERS WILL NOT SELF-DELETE
+# You'll have to periodically clean out old times
+#
+# Next pending timer goes into bar under header
+# Next "show-in-sidebar" timers go into sidebar
+# If all timers are in the past, timerbar hides
+#
+# TODO: Override a specific timer for timerbar
+# TODO: Automatically calculate movie night times
+#       so we don't need to enter them here
+#
+#==========================================================
+
+# How many upcoming timers should be in sidebar
+show-in-sidebar: 3
+
+# List of timers
+timers:
+  - title: "Friday Movie Night"
+    time: 2015-11-27 18:00 -0600
+  
+  - title: "Season Finale"
+    time: 2015-11-28 08:00 -0800

--- a/_data/timers.yml
+++ b/_data/timers.yml
@@ -53,8 +53,8 @@ timers:
   - title: Thanksgiving noon
     time: 2015-11-26 12:00 -0600
     
-  - title: Season Finale
-    time: 2015-11-28 08:00 -0800
-    
   - title: A thing Happens
     time: 2015-12-25 00:00 -0600
+    
+  - title: Season Finale
+    time: 2015-11-28 08:00 -0800

--- a/_data/timers.yml
+++ b/_data/timers.yml
@@ -3,13 +3,13 @@
 # Shizuka Kamishima - 2015-11-23
 #
 # timers:
-#   - title: Friday Movie Night
-#     time: 2015-11-27 19:00 -0500
-#     url: "/news/2015-11-20-lottery.html"
-#
 #   - title: Pony Episode
 #     time: 2015-11-28 10:30 -0600
-# 
+#
+#   - title: Some special event
+#     time: 2015-12-25 00:00 +0000
+#     url: /news/2015-12-25-christmas.html
+#
 # Spaces matter! Line up the - and values, blank lines okay
 # "url" field is optional, "title" and "time" are not
 # "title" will be lowercased when inserted into header bar
@@ -37,24 +37,16 @@
 # If all timers are in the past, timerbar hides
 #
 # TODO: Override a specific timer for timerbar
-# TODO: Automatically calculate movie night times
-#       so we don't need to enter them here
 #
 #==========================================================
 
 # How many upcoming timers should be in sidebar
 show-in-sidebar: 3
 
+# How many weeks of movie nights in advance to generate
+weeks-in-advance: 2
+
 # List of timers
 timers:
-  - title: Something in the past
-    time: 2015-11-22 02:23 -0600
-    
-  - title: Thanksgiving noon
-    time: 2015-11-26 12:00 -0600
-    
-  - title: A thing Happens
-    time: 2015-12-25 00:00 -0600
-    
-  - title: Season Finale
+  - title: MLP:FIM Season Finale
     time: 2015-11-28 08:00 -0800

--- a/_data/timers.yml
+++ b/_data/timers.yml
@@ -43,7 +43,7 @@
 # How many upcoming timers should be in sidebar
 show-in-sidebar: 3
 
-# How many weeks of movie nights in advance to generate
+# How many weeks of movie nights in advance to generate (includes this week)
 weeks-in-advance: 2
 
 # List of timers

--- a/_data/timers.yml
+++ b/_data/timers.yml
@@ -47,8 +47,14 @@ show-in-sidebar: 3
 
 # List of timers
 timers:
-  - title: Friday Movie Night
-    time: 2015-11-27 18:00 -0600
-  
+  - title: Something in the past
+    time: 2015-11-22 02:23 -0600
+    
+  - title: Thanksgiving noon
+    time: 2015-11-26 12:00 -0600
+    
   - title: Season Finale
     time: 2015-11-28 08:00 -0800
+    
+  - title: A thing Happens
+    time: 2015-12-25 00:00 -0600

--- a/_includes/mstr_postfix.html
+++ b/_includes/mstr_postfix.html
@@ -7,6 +7,7 @@
   ga('create', 'UA-30342880-1', 'auto');
   ga('send', 'pageview');
 </script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
 <script type="text/javascript" src="/assets/js/brst-timers.js"></script>
 <script type="text/javascript" src="/assets/js/brst-countdowns.js"></script>
 </body>

--- a/_includes/mstr_postfix.html
+++ b/_includes/mstr_postfix.html
@@ -7,5 +7,7 @@
   ga('create', 'UA-30342880-1', 'auto');
   ga('send', 'pageview');
 </script>
+<script type="text/javascript" src="/assets/js/brst-timers.js"></script>
+<script type="text/javascript" src="/assets/js/brst-countdowns.js"></script>
 </body>
 </html>

--- a/_includes/mstr_postfix.html
+++ b/_includes/mstr_postfix.html
@@ -8,6 +8,7 @@
   ga('send', 'pageview');
 </script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.4.1/moment-timezone-with-data.min.js"></script>
 <script type="text/javascript" src="/assets/js/brst-timers.js"></script>
 <script type="text/javascript" src="/assets/js/brst-countdowns.js"></script>
 </body>

--- a/_includes/zone_embeds.html
+++ b/_includes/zone_embeds.html
@@ -1,8 +1,12 @@
+{% capture codeBlock %}
+  {% assign embed = site.data.embed-switcher.embeds[site.data.embed-switcher.live] %}
+  {% if embed == "" or embed == nil %}{% assign embed = site.data.embed-switcher.failsafe %}{% endif %}
+{% endcapture %}{% assign codeBlock = nil %}
 <section id='embedsection'>
   <div id="streambox">
-    <iframe id="if_stream" name="if_stream" width="640" height="392" frameborder="0" style="border:0;outline:0" scrolling="no" src="{{ site.data.embed-switcher.embeds[site.data.embed-switcher.live] }}"></iframe>
+    <iframe id="if_stream" name="if_stream" width="640" height="392" frameborder="0" style="border:0;outline:0" scrolling="no" src="{{ embed }}"></iframe>
     <div class="embedui">
-      <a class="btn refresh noext" href="{{ site.data.embed-switcher.embeds[site.data.embed-switcher.live] }}" target="if_stream"><span class="caption">Refresh Stream</span></a>
+      <a class="btn refresh noext" href="{{ embed }}" target="if_stream"><span class="caption">Refresh Stream</span></a>
       <a class="btn popout" href="javascript:popoutStream()"><span class="caption">Popout Stream</span></a>
       <a class="btn chatbox" href="javascript:toggleChatbox()"><span class="caption">Show/Hide Chat</span></a>
     </div>

--- a/_includes/zone_embeds.html
+++ b/_includes/zone_embeds.html
@@ -1,8 +1,8 @@
 <section id='embedsection'>
   <div id="streambox">
-    <iframe id="if_stream" name="if_stream" width="640" height="392" frameborder="0" style="border:0;outline:0" scrolling="no" src="http://www.ustream.tv/embed/16227134?html5ui"></iframe>
+    <iframe id="if_stream" name="if_stream" width="640" height="392" frameborder="0" style="border:0;outline:0" scrolling="no" src="{{ site.data.embed-switcher.embeds[site.data.embed-switcher.live] }}"></iframe>
     <div class="embedui">
-      <a class="btn refresh noext" href="http://www.ustream.tv/embed/16227134?html5ui" target="if_stream"><span class="caption">Refresh Stream</span></a>
+      <a class="btn refresh noext" href="{{ site.data.embed-switcher.embeds[site.data.embed-switcher.live] }}" target="if_stream"><span class="caption">Refresh Stream</span></a>
       <a class="btn popout" href="javascript:popoutStream()"><span class="caption">Popout Stream</span></a>
       <a class="btn chatbox" href="javascript:toggleChatbox()"><span class="caption">Show/Hide Chat</span></a>
     </div>

--- a/_includes/zone_news.html
+++ b/_includes/zone_news.html
@@ -33,6 +33,6 @@
 </article>
 </div>
 
-<!-- % include zone_sidebar.html % -->
+{% include zone_sidebar.html %}
 
 </section>

--- a/_includes/zone_sidebar.html
+++ b/_includes/zone_sidebar.html
@@ -1,9 +1,6 @@
 <aside id="sidebar">
   <h3>upcoming events</h3>
-  <ul>
-    <li><p>Friday Movie Night<br>
-    6d 14h 20m</p></li>
-    <li><p>Lottery Closes<br>
-    6d 14h 20m</p></li>
+  <ul id="sidetimers">
+    
   </ul>
 </aside>

--- a/_includes/zone_sidebar.html
+++ b/_includes/zone_sidebar.html
@@ -1,4 +1,4 @@
-<aside class="sidebar">
+<aside id="sidebar">
   <h3>upcoming events</h3>
   <ul>
     <li><p>Friday Movie Night<br>

--- a/_includes/zone_timerbar.html
+++ b/_includes/zone_timerbar.html
@@ -1,4 +1,4 @@
-<div id="timerbar">
-  <div id="timertitle">countdown to next event</div>
-  <div id="timerclock">6d 15h 30m</div>
+<div id="timerbar" class="hide">
+  <div id="timertitle"></div>
+  <div id="timerclock"></div>
 </div>

--- a/_includes/zone_timerbar.html
+++ b/_includes/zone_timerbar.html
@@ -1,4 +1,4 @@
-<div id="timerbar" class="hide">
-  <div id="timertitle"></div>
-  <div id="timerclock"></div>
+<div id="timerbar">
+  <div id="timertitle">&nbsp;</div>
+  <div id="timerclock">&nbsp;</div>
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,6 +1,6 @@
 {% include mstr_prefix.html %}
 {% include zone_header.html %}
-<!-- % include zone_timerbar.html % -->
+{% include zone_timerbar.html %}
 <div id="contentwrapper">
 {% include zone_embeds.html %}
 <hr>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,13 +1,13 @@
 {% include mstr_prefix.html %}
 {% include zone_header.html %}
-<!-- % include zone_timerbar.html % -->
+{% include zone_timerbar.html %}
 <div id="contentwrapper">
 <section class="article-wrap">
 <article>
 {{ content }}
 </article>
 </section>
-<!-- % include zone_sidebar.html % -->
+{% include zone_sidebar.html %}
 {% include zone_footer.html %}
 </div>
 {% include mstr_postfix.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,6 @@
 {% include mstr_prefix.html %}
 {% include zone_header.html %}
-<!-- % include zone_timerbar.html % -->
+{% include zone_timerbar.html %}
 <div id="contentwrapper">
 <section class="article-wrap">
 <article>
@@ -9,7 +9,7 @@
 </article>
 {% include meta_newsnav.html post=page %}
 </section>
-<!-- % include zone_sidebar.html % -->
+{% include zone_sidebar.html %}
 {% include zone_footer.html %}
 </div>
 {% include mstr_postfix.html %}

--- a/_sass/_zone_news.scss
+++ b/_sass/_zone_news.scss
@@ -13,7 +13,7 @@ $boxcolor: royalblue;
   margin-bottom: 1.5em;
 }
 
-.sidebar {
+#sidebar {
   width: $width-sidebar;
   margin-top: 2em;
   padding: 1em;

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -8,25 +8,22 @@ var timertitle = document.getElementById("timertitle");
 var timerclock = document.getElementById("timerclock");
 var sidebar = document.getElementById("sidebar");
 
-var _second = 1000;
-var _minute = _second * 60;
-var _hour = _minute * 60;
-var _day = _hour * 24;
-
 var interval; //to hold the setInterval()
 
-var nextFridayMovie = moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5);
-var nextSaturdayMovie = moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6);
+var nextFridayMovie = { title: "Friday Movie Night", moment: moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5) };
+var nextSaturdayMovie = { title: "Saturday Movie Night", moment: moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6) };
 
 function loadTimers() {
   console.log("Adding moments to timers...");
   console.log(brst_timers.length);
   // add momentjs objects to timers
   for (var i = 0; i < brst_timers.length; i++) {
-    console.log('Loaded timer: "' + brst_timers[i].title + '"');
     brst_timers[i]["moment"] = moment(brst_timers[i].time, "YYYY-MM-DD HH:mm Z");
+    console.log('Loaded timer: "' + brst_timers[i].title + '" @ ' + brst_timers[i].moment.toISOString());
   }
+  brst_timers.push(nextFridayMovie, nextSaturdayMovie);
   brst_timers.sort(cmpTimers);
+  update();
 }
 
 function cmpTimers(a, b) {
@@ -37,4 +34,36 @@ function cmpTimers(a, b) {
   return 0;
 }
 
+function update() {
+  var now = moment();
+  var shown = 0;
+  var titledone = false;
+  
+  for (var i = 0; i < brst_timers.length; i++) {
+    var timer = brst_timers[i];
+    if (now.isAfter(timer.moment)) {
+      continue;
+    }
+    shown++;
+    if (!titledone) {
+      var time = calcRemaining(timer.moment);
+      timertitle.innerHTML = timer.title;
+      timerclock.innerHTML = time;
+      timerbar.classList.toggle("hide");
+      titledone = true;
+    }
+  }
+}
+
+function calcRemaining(mo) {
+  var delta = mo.diff(moment(), 'minutes');
+  var days = Math.floor(delta / (60 * 24));
+  delta -= days * 60 * 24;
+  var hours = Math.floor(delta / 60);
+  delta -= hours * 60;
+  var minutes = delta;
+  return days + "d " + hours + "h " + minutes + "m";
+}
+
 window.onload = loadTimers;
+interval = setInterval(update, 30000);

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -24,7 +24,7 @@ function loadTimers() {
 }
 
 function genAdvanceMovies(amt) {
-  for (var i = 0; i <= amt; i++) {
+  for (var i = 0; i < amt; i++) {
     var fri = { title: "Friday Movie Night", moment: moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5 +(7*i)), url: "" };
     var sat = { title: "Saturday Movie Night", moment: moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6 +(7*i)), url: "" };
     brst_timers.push(fri, sat);

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -18,8 +18,6 @@ var interval; //to hold the setInterval()
 var nextFridayMovie = moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5);
 var nextSaturdayMovie = moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6);
 
-var now = moment();
-
 function loadTimers() {
   console.log("Adding moments to timers...");
   console.log(brst_timers.length);
@@ -28,6 +26,15 @@ function loadTimers() {
     console.log('Loaded timer: "' + brst_timers[i].title + '"');
     brst_timers[i]["moment"] = moment(brst_timers[i].time, "YYYY-MM-DD HH:mm Z");
   }
+  brst_timers.sort(cmpTimers);
+}
+
+function cmpTimers(a, b) {
+  if (a.moment.isBefore(b.moment))
+    return -1;
+  if (a.moment.isAfter(b.moment))
+    return 1;
+  return 0;
 }
 
 window.onload = loadTimers;

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -1,3 +1,5 @@
+---
+---
 /**
  * Bronystate 3.0 - Countdown Timers
  * Shizuka Kamishima - 2015-11-23

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -8,27 +8,26 @@ var timertitle = document.getElementById("timertitle");
 var timerclock = document.getElementById("timerclock");
 var sidebar = document.getElementById("sidebar");
 
-// -- From brst-timers.js --
-//var showInSidebar = <number of timers to show in sidebar>
-//var brst_timers[] = array of timer structs:
-//  {"title":"Movie Night", "time":"2015-11-27 18:00 -0600", "url":"/path/to/lotto"}
-
 var _second = 1000;
 var _minute = _second * 60;
 var _hour = _minute * 60;
 var _day = _hour * 24;
 
-var timer; //to hold the setInterval()
+var interval; //to hold the setInterval()
 
 var nextFridayMovie = moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5);
-var nextSaturdayMovie = moment.tz("America/New_York").hour(13).minute(0).second(0).millisecond(0).day(6);
+var nextSaturdayMovie = moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6);
 
-var j = 0;
-var timerlist;
 var now = moment();
 
-for (var i = 0; i++; i < showInSidebar) {
-  // i = total timers loaded
-  // j = index in timer data list
-  
+function loadTimers() {
+  console.log("Adding moments to timers...");
+  console.log(brst_timers.length);
+  // add momentjs objects to timers
+  for (var i = 0; i < brst_timers.length; i++) {
+    console.log('Loaded timer: "' + brst_timers[i].title + '"');
+    brst_timers[i]["moment"] = moment(brst_timers[i].time, "YYYY-MM-DD HH:mm Z");
+  }
 }
+
+window.onload = loadTimers;

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -1,10 +1,34 @@
 /**
- * Bronystate 3.0 - Countdown Timers
+ * Bronystate 3.0 - Countdown Script
  * Shizuka Kamishima - 2015-11-23
  */
 
 var timerbar = document.getElementById("timerbar");
 var timertitle = document.getElementById("timertitle");
 var timerclock = document.getElementById("timerclock");
+var sidebar = document.getElementById("sidebar");
 
+// -- From brst-timers.js --
+//var showInSidebar = <number of timers to show in sidebar>
+//var brst_timers[] = array of timer structs:
+//  {"title":"Movie Night", "time":"2015-11-27 18:00 -0600", "url":"/path/to/lotto"}
 
+var _second = 1000;
+var _minute = _second * 60;
+var _hour = _minute * 60;
+var _day = _hour * 24;
+
+var timer; //to hold the setInterval()
+
+var nextFridayMovie = moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5);
+var nextSaturdayMovie = moment.tz("America/New_York").hour(13).minute(0).second(0).millisecond(0).day(6);
+
+var j = 0;
+var timerlist;
+var now = moment();
+
+for (var i = 0; i++; i < showInSidebar) {
+  // i = total timers loaded
+  // j = index in timer data list
+  
+}

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -39,12 +39,14 @@ function update() {
   var shown = 0;
   var titledone = false;
   
+  sidetimers.innerHTML = "";
+  
   for (var i = 0; i < brst_timers.length; i++) {
     var timer = brst_timers[i];
     if (now.isAfter(timer.moment)) {
       continue;
     }
-    if (shown > showInSidebar) {
+    if (shown == showInSidebar) {
       break;
     }
     shown++;
@@ -53,6 +55,7 @@ function update() {
       timerclock.innerHTML = calcRemaining(timer.moment);
       titledone = true;
     }
+    sidetimers.innerHTML += "<li>" + sideTimeText(timer) + "</li>";
   }
 }
 

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -44,14 +44,22 @@ function update() {
     if (now.isAfter(timer.moment)) {
       continue;
     }
+    if (shown > showInSidebar) {
+      break;
+    }
     shown++;
     if (!titledone) {
-      var time = calcRemaining(timer.moment);
       timertitle.innerHTML = timerTitle(timer) + " in";
-      timerclock.innerHTML = time;
+      timerclock.innerHTML = calcRemaining(timer.moment);
       titledone = true;
     }
   }
+}
+
+function sideTimeText(timer) {
+  var title = timerTitle(timer);
+  var time = calcRemaining(timer.moment);
+  return "<p>" + title + "<br>" + time + "</p>";
 }
 
 function timerTitle(timer) {

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -1,5 +1,3 @@
----
----
 /**
  * Bronystate 3.0 - Countdown Timers
  * Shizuka Kamishima - 2015-11-23

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -49,7 +49,6 @@ function update() {
       var time = calcRemaining(timer.moment);
       timertitle.innerHTML = timer.title;
       timerclock.innerHTML = time;
-      timerbar.classList.toggle("hide");
       titledone = true;
     }
   }

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -6,12 +6,12 @@
 var timerbar = document.getElementById("timerbar");
 var timertitle = document.getElementById("timertitle");
 var timerclock = document.getElementById("timerclock");
-var sidebar = document.getElementById("sidebar");
+var sidetimers = document.getElementById("sidetimers");
 
 var interval; //to hold the setInterval()
 
-var nextFridayMovie = { title: "Friday Movie Night", moment: moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5) };
-var nextSaturdayMovie = { title: "Saturday Movie Night", moment: moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6) };
+var nextFridayMovie = { title: "Friday Movie Night", moment: moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5), url: "" };
+var nextSaturdayMovie = { title: "Saturday Movie Night", moment: moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6), url: "" };
 
 function loadTimers() {
   console.log("Adding moments to timers...");
@@ -47,7 +47,11 @@ function update() {
     shown++;
     if (!titledone) {
       var time = calcRemaining(timer.moment);
-      timertitle.innerHTML = timer.title;
+      var title = timer.title;
+      if (timer.url !== "undefined" && timer.url != "") {
+        title = '<a href="' + timer.url + '">' + title + '</a>';
+      }
+      timertitle.innerHTML = title + " in";
       timerclock.innerHTML = time;
       titledone = true;
     }

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -1,0 +1,10 @@
+/**
+ * Bronystate 3.0 - Countdown Timers
+ * Shizuka Kamishima - 2015-11-23
+ */
+
+var timerbar = document.getElementById("timerbar");
+var timertitle = document.getElementById("timertitle");
+var timerclock = document.getElementById("timerclock");
+
+

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -47,15 +47,19 @@ function update() {
     shown++;
     if (!titledone) {
       var time = calcRemaining(timer.moment);
-      var title = timer.title;
-      if (timer.url !== "undefined" && timer.url != "") {
-        title = '<a href="' + timer.url + '">' + title + '</a>';
-      }
-      timertitle.innerHTML = title + " in";
+      timertitle.innerHTML = timerTitle(timer) + " in";
       timerclock.innerHTML = time;
       titledone = true;
     }
   }
+}
+
+function timerTitle(timer) {
+  var title = timer.title;
+  if (timer.url !== "undefined" && timer.url != "") {
+    title = '<a href="' + timer.url + '">' + title + '</a>';
+  }
+  return title;
 }
 
 function calcRemaining(mo) {

--- a/assets/js/brst-countdowns.js
+++ b/assets/js/brst-countdowns.js
@@ -10,9 +10,6 @@ var sidetimers = document.getElementById("sidetimers");
 
 var interval; //to hold the setInterval()
 
-var nextFridayMovie = { title: "Friday Movie Night", moment: moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5), url: "" };
-var nextSaturdayMovie = { title: "Saturday Movie Night", moment: moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6), url: "" };
-
 function loadTimers() {
   console.log("Adding moments to timers...");
   console.log(brst_timers.length);
@@ -21,9 +18,17 @@ function loadTimers() {
     brst_timers[i]["moment"] = moment(brst_timers[i].time, "YYYY-MM-DD HH:mm Z");
     console.log('Loaded timer: "' + brst_timers[i].title + '" @ ' + brst_timers[i].moment.toISOString());
   }
-  brst_timers.push(nextFridayMovie, nextSaturdayMovie);
+  genAdvanceMovies(weeksInAdvance);
   brst_timers.sort(cmpTimers);
   update();
+}
+
+function genAdvanceMovies(amt) {
+  for (var i = 0; i <= amt; i++) {
+    var fri = { title: "Friday Movie Night", moment: moment.tz("America/New_York").hour(19).minute(0).second(0).millisecond(0).day(5 +(7*i)), url: "" };
+    var sat = { title: "Saturday Movie Night", moment: moment.tz("America/New_York").hour(14).minute(0).second(0).millisecond(0).day(6 +(7*i)), url: "" };
+    brst_timers.push(fri, sat);
+  }
 }
 
 function cmpTimers(a, b) {

--- a/assets/js/brst-timers.js
+++ b/assets/js/brst-timers.js
@@ -8,6 +8,8 @@
 
 var showInSidebar = {{ site.data.timers.show-in-sidebar }};
 
+var weeksInAdvance = {{ site.data.timers.weeks-in-advance }};
+
 var brst_timers = [
 {% for timer in site.data.timers.timers %}{
   "title": "{{timer.title}}", 

--- a/assets/js/brst-timers.js
+++ b/assets/js/brst-timers.js
@@ -1,0 +1,17 @@
+---
+---
+/**
+ * Bronystate 3.0 - Countdown Timers
+ * Shizuka Kamishima - 2015-11-23
+ * Generated on {{ site.time | date: "%F" }} by Jekyll
+ */
+
+var showInSidebar = {{ site.data.timers.show-in-sidebar }};
+
+var brst_timers = [
+{% for timer in site.data.timers.timers %}{
+  "title": "{{timer.title}}", 
+  "time": "{{timer.time}}", 
+  "url": "{{timer.url}}"
+},
+{% endfor %}];

--- a/index_rules.md
+++ b/index_rules.md
@@ -86,7 +86,7 @@ You may continue to appeal a ban if your first attempt is rejected.
 
 *[Eastern Time]: UTC-5, -4 during US Daylight Saving Time
 
-Movie Nights are held every Friday at 7pm Eastern Time and Saturday at 1pm Eastern Time, and consist of two
+Movie Nights are held every Friday at 7pm Eastern Time and Saturday at 2pm Eastern Time, and consist of two
 movies and two episodes of *My Little Pony*, chosen by our users.
 
 Each week, we send out a lottery form you can use to cast your vote. The form consists of your:


### PR DESCRIPTION
Adds embed switcher: single var "live" in _data/embed-switcher.yml, set to codename for stream, streams listed below it, pushes src to static build, fails to Technical Derpiculties video if url is missing or live is malformed

Adds countdown timers: what a bitch to implement, will automatically generate the next few weeks of movie nights (configurable) plus any extra events we want to have timers for, urls optional, next upcoming timer appears in timerbar, automatically updates when it expires