### PR TITLE
Pagination fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'jekyll-paginate'

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ kramdown:
   hard_wrap: false
   smart_quotes: ["apos", "apos", "quot", "quot"]
 
+gems: ["jekyll-paginate"]
+
 sass:
   sass_dir: _sass
 


### PR DESCRIPTION
Github's Jekyll 3 upgrade does not include jekyll-paginate, this fixes that so we have pages of news back.