### PR TITLE
Use the ustream HTML5 playback

### DIFF
--- a/_data/embed-switcher.yml
+++ b/_data/embed-switcher.yml
@@ -14,9 +14,9 @@ embeds:
   # MAIN STREAMS
   amethyst:   ""
   beryl:      ""
-  cookie:     "http://www.ustream.tv/embed/16198304?html5ui=1" # BRST20131018
-  diamond:    "http://www.ustream.tv/embed/16227134?html5ui=1" # BRST20131023
-  emerald:    "http://www.ustream.tv/embed/16296194?html5ui=1" # BRST20131106
+  cookie:     "http://www.ustream.tv/embed/16198304?html5ui=1&htmlplayback=1" # BRST20131018
+  diamond:    "http://www.ustream.tv/embed/16227134?html5ui=1&htmlplayback=1" # BRST20131023
+  emerald:    "http://www.ustream.tv/embed/16296194?html5ui=1&htmlplayback=1" # BRST20131106
   feldspar:   ""
   garnet:     ""
   hematite:   ""

--- a/_includes/zone_embeds.html
+++ b/_includes/zone_embeds.html
@@ -4,7 +4,7 @@
 {% endcapture %}{% assign codeBlock = nil %}
 <section id='embedsection'>
   <div id="streambox">
-    <iframe id="if_stream" name="if_stream" width="640" height="392" frameborder="0" style="border:0;outline:0" scrolling="no" src="{{ embed }}"></iframe>
+    <iframe id="if_stream" name="if_stream" width="640" height="392" frameborder="0" style="border:0;outline:0" scrolling="no" src="{{ embed }}" allowfullscreen="true" webkitallowfullscreen="true"></iframe>
     <div class="embedui">
       <a class="btn refresh noext" href="{{ embed }}" target="if_stream"><span class="caption">Refresh Stream</span></a>
       <a class="btn popout" href="javascript:popoutStream()"><span class="caption">Popout Stream</span></a>


### PR DESCRIPTION
This makes the embedded ustream player work without Flash.

Since going forward Flash support is going to decrease, I think it's a good idea to switch to the fully html5 player.