### PR TITLE
Post ban appeals publicly on the site

### DIFF
--- a/_posts/2020-01-17-banappeals.md
+++ b/_posts/2020-01-17-banappeals.md
@@ -1,0 +1,146 @@
+---
+title: 2019 Ban Appeals
+date: 2020-01-17
+author: Eggplantade
+tags: [appeals]
+---
+
+Happy 2020 everyone!  They say hindsight is 2020, so let's take a look backward at some of last year's ban appeals.  As a reminder, we post ban appeals publicly as indicated on our rules page.  Normally this would be done by bronystate's staff, but this is a guest post by yours truly, because... well, you can see below.
+
+First ban appeal - Eggplantade - 2019-07-29
+-------------------------------------------
+
+To Bronystate's staff,
+
+This is eggplantade, the brony who you believe is a "stupid",
+"unbelievably dense child" and "ignorant dickweasel" who "think\[s\]
+everything is hate speech"; who you say fuck-you to because of where I
+live; whose opinions you call "libtard shit"; who you compare to a
+stalker; who you claim has a reading disability, then accuse of
+"trying to start something" when the lie you told to justify your
+claim is called out; who you criticize for "trying to climb to a moral
+highground" when I point out that I do not respond in kind to your
+verbal abuse; who you have kicked from Bronystate twice for pushing
+back against your hostile, demeaning, toxic behavior; and who you have
+finally banned on July 13, 2017 for talking to you about your
+hostility toward people in the stream chat.  I have logs from IRC of
+what you've done.  Or, to echo Kitten, "You choose to come in here and
+try to provoke members of the community.  And don't deny that you do,
+I have the logs."
+
+I am appealing that ban.  You, in evaluating this ban appeal, are
+representing a group of moderators who have done these things.  You
+have depleted my good faith long ago.  I anticipate that you will once
+again dismiss what I am saying and respond by continuing to attack me.
+I am not giving you a private channel to reply so that you won't be
+emboldened by secrecy.  You can respond to this appeal in the stream
+chat.  Mention "eggplantade" with your response so that I can find it.
+
+Kitten banned me because I spoke out about the provocative behavior of
+Bronystate's staff after he demanded that I "chill \[my\] fucking jets
+and stop actively trying to provoke people in this chat".  Kitten's
+outrage, viewed in light of the things Bronystate's staff says,
+reflects a double standard for provocative conduct.  My conduct has
+consistently exceeded the standards of courtesy held by a chat where
+people are told "any decent doctor will tell you that you're full of
+shit" because they reject Kitten's racialist beliefs, "you're just
+whining about something" because they express support for protests
+against police racial bias, and "your bitchy opinions don't \[matter\]"
+because they express concern about how Trump's anti-trans agenda will
+affect them.  My conduct has consistently been less provocative than
+the moderators who declare that "libtards don't care for trifling
+things like facts", that "the SJWs like to cling to a single, harmless
+instance of 'microaggressions'", that over twenty women going public
+about Donald Trump's sense of entitlement to use their bodies against
+their will was "overdrummed as more than it was, and it's a lazy
+attempt at slander", and that the yardstick for judging whether
+Trump's policies are bad is "when Trump starts electrocuting the
+gays".  My conduct has consistently been more respectful than the
+moderators who label people with degrading slurs such as "faggots",
+"shitheads", "idiots", "talking cunt", "cucks", "little shits",
+"pricks", "libtards", and "SJWs".  This pattern of conduct reflects
+what Bronystate judges acceptable, and I have not stooped so low.
+
+I was not intentionally provoking Kitten, as he claimed.  Rather, I
+was trying to understand why he sympathizes with a white supremacist
+who fuels hatred by generating racist memes, and subsequently to
+fathom how he can believe that those white supremacist memes are not
+racist, and subsequently to remind him of Bronystate's actual
+standards of conduct.  If Kitten, who says that I'm a "dense child"
+and "ignorant dickweasel" who "think\[s\] everything is hate speech",
+feels that I am provoking him by voicing my perception of what he
+said, he should recall his own belief that "to have to face off
+against opinions you don't agree with... \[is\] part of growing up".  I
+did not try to silence Kitten when he was verbally abusive toward me.
+Silencing someone is not a way of facing off against opinions you
+don't agree with.
+
+Kitten's ban was a self-serving abuse of power.  It functions to
+perpetuate his misbehavior and that of his peers by silencing
+discussion of it.  He justifies it by framing that discussion as
+provocation.  This reflects his hypocritical unwillingness to receive
+even a shadow of the animus that he expresses toward others.  While I
+have complied with the ban because I know he has your support, the ban
+is unethical and I do not recognize it as legitimate.
+
+Again, everything I have done exceeds Bronystate's extremely low
+standards for courteous and respectful conduct.  Again, I was not
+intentionally provoking Kitten.  Again, Kitten's ban was unethical.  I
+will continue treating Bronystate's staff with more respect than they
+have shown for female presidential candidates ("god I fucking hate
+her", "What the fuck senate wwoman", "facts are only important when
+they don't make madame president look bad").  The right thing for you
+to do is to remove the ban.
+
+Second ban appeal - Eggplantade - 2019-10-31
+--------------------------------------------
+
+To bronystate's staff,
+
+This is eggplantade, who you banned on September 9, 2019 for
+repeatedly recalling hostile and patronizing acts carried out by
+bronystate's staff and asking how to counteract them.  While it's hard
+to assess your side of the issue as long as you won't discuss it, I
+take it you believe these acts no longer matter because they happened
+long ago, they should be forgotten, and they carry no weight because
+bronystate is a friendly, fun, and goofy place.  Still, repeated
+experience has taught me that it's not safe to let my guard down and
+enjoy the stream in the presence of some of bronystate's staff.  What
+I can do is to stop listening to them and enjoy the company of people
+I'm able to appreciate.
+
+I became a regular visitor to bronystate years ago because it was fun
+to see new MLP episodes and new shows, to share the experience and
+hear other fans' reactions and observations.  You know how that
+experience soured for me.  Nevertheless, there are still people I like
+there.
+
+Several things have changed my opinion since I returned this summer.
+I saw in \#the-swamp how several of the staff who used to defend Donald
+Trump and rally around aspects of the alt-right worldview were now
+concerned about them.  I saw that a moderator who used to wield his
+admin authority to bully and belittle me was now remaining civil.
+After I was banned this year, I spoke with a moderator who was willing
+to listen and persuade rather than dismiss and demean.  This
+experience has alleviated my worst concerns about the culture that
+bronystate's staff cultivates.  I'm no longer worried that
+bronystate's culture may poison the brony community.
+
+Although there can be no reconciliation as long as you see me as a
+deficient creature that does not merit a normal degree of respect, I
+can make a clean break that achieves what we both want.  I would like
+to return to bronystate, stop discussing your past behavior, block the
+individuals who have made bronystate unwelcoming, and participate in
+the stream chat with the people I want to talk to.  I will be more
+tolerant when I perceive hostility, contempt, or prejudice underlying
+people's behavior.  This will insulate you from the criticism you do
+not tolerate without leaving me vulnerable to degrading treatment I'm
+not permitted to defend against.
+
+I guess I should have expected bronystate to retain the norms of the
+infamous chans that spawned it.  Let us see if bronystate has also
+retained the openness and permissiveness of the chans as well, if it
+will allow me back.
+
+Sincerely,
+eggplantade


### PR DESCRIPTION
These changes are to publicly post ban appeals that Bronystate has received (at least, the ones I'm aware of).  This brings Bronystate into compliance with its rule "Appeals will be posted publicly on the site".

Other than the introductory text and headings, the text is taken directly from ban appeals.